### PR TITLE
🐳 Automagically publish Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,5 @@ deploy:
     on:
       tags: true
 after_deploy:
+  - sh scripts/trigger-docker-image-build.sh
   - sh scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 set -o xtrace
 
-# Deploy to dev
-echo "Deploying to dev."
-sshpass -p$TRAVIS_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@dev.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | bash';
-
-# Deploy to test if tag
 if [ -z "$TRAVIS_TAG" ];
 then
-  echo "Not deploying to test because this is not a tag.";
+  # Deploy to dev
+ echo "Deploying to dev."
+ sshpass -p$TRAVIS_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@dev.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | bash';
 else
+  # Deploy to test if tag
   echo "Deploying to test because this is a tag."
   sshpass -p$TRAVIS_TEST_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@test-ssh.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | POC_VERSION='"$TRAVIS_TAG"' bash';
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,5 +11,5 @@ then
   echo "Not deploying to test because this is not a tag.";
 else
   echo "Deploying to test because this is a tag."
-  sshpass -p$TRAVIS_TEST_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@test-ssh.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | bash';
+  sshpass -p$TRAVIS_TEST_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@test-ssh.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | POC_VERSION='"$TRAVIS_TAG"' bash';
 fi

--- a/scripts/trigger-docker-image-build.sh
+++ b/scripts/trigger-docker-image-build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -o xtrace
+
+if [ -z "$TRAVIS_TAG" ];
+then
+  # build from master
+  POC_VERSION=master
+else
+  # build from tag
+  POC_VERSION="$TRAVIS_TAG"
+fi
+
+body='{
+  "request": {
+    "branch":"master",
+    "config": {
+      "env": {
+        "POC_VERSION": "'$POC_VERSION'"
+      }
+    }
+  }
+}'
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $TRAVIS_API_TOKEN" \
+  -d "$body" \
+  https://api.travis-ci.org/repo/esaude%2Fesaude-poc-docker/requests

--- a/scripts/trigger-docker-image-build.sh
+++ b/scripts/trigger-docker-image-build.sh
@@ -10,6 +10,10 @@ else
   POC_VERSION="$TRAVIS_TAG"
 fi
 
+# Notify to slack
+SLACK_MESSAGE="New eSaude POC version ($POC_VERSION) published <https://bintray.com/esaude/poc/distributable|here>"
+curl -X POST --data-urlencode 'payload={"username": "eSaude Bintray", "text": "'"$SLACK_MESSAGE"'", "icon_url": "https://bintray.com/assets/favicon.png"}' $SLACK_WEBHOOK_URL
+
 body='{
   "request": {
     "branch":"master",


### PR DESCRIPTION
This PR introduces automatic building of Docker images when new code is merged to `master` or when new tags are pushed.

The process is as follows:

1. Publish a new distributable to Bintray [here](https://bintray.com/esaude/poc/distributable).
2. Trigger a build of the [eSaude POC Docker repo](https://travis-ci.org/esaude/esaude-poc-docker/builds), which builds a new POC Docker image and publishes it [here](https://bintray.com/esaude/poc-docker/poc).
3. Deploy to [dev](http://dev.esaude.org) or [test](http://test.esaude.org) depending on whether we are building `master` or a tag.

Steps 1 & 3 were already implemented. This PR implements step 2.