### PR TITLE
Alter build for reports, fixes #223.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,8 @@ module.exports = function (grunt) {
   var proxySnippet = require('grunt-connect-proxy/lib/utils').proxyRequest;
 
   // Configurable paths for the application
+  var POC_BASE = 'poc';
+
   var appConfig = {
     app: require('./bower.json').appPath || 'app',
     dist: 'dist'
@@ -322,7 +324,8 @@ module.exports = function (grunt) {
           html: {
             steps: {
               js: ['concat'],
-              css: ['cssmin']
+              css: ['cssmin'],
+              report: ['cssmin']
             },
             post: {}
           }
@@ -351,6 +354,11 @@ module.exports = function (grunt) {
         ],
         patterns: {
           js: [[/(images\/[^'']*\.(png|jpg|jpeg|gif|webp|svg))/g, 'Replacing references to images']]
+        },
+        blockReplacements: {
+          report: function (block) {
+            return '<link rel="stylesheet" href="/' + POC_BASE + '/' + block.dest + '">';
+          }
         }
       }
     },
@@ -492,7 +500,8 @@ module.exports = function (grunt) {
       'using-router': {
         router: function (filepath) {
           if(filepath.startsWith('dist')) {
-            return filepath.replace('dist', 'poc');
+
+            return filepath.replace('dist', POC_BASE);
           }
 
           return filepath;

--- a/app/patient-details/views/patient-arv-pickup-history-report.html
+++ b/app/patient-details/views/patient-arv-pickup-history-report.html
@@ -1,4 +1,4 @@
-<!-- build:css styles/report.patient-arv-pickup-history.min.css -->
+<!-- build:report styles/report.patient-arv-pickup-history.min.css -->
 <link href="../../../bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet"  media="print"/>
 <link href="../../styles/patient-arv-pickup-history-report.css" rel="stylesheet" media="print">
 <!-- endbuild -->

--- a/app/patient-details/views/patient-daily-hospital-process-report.html
+++ b/app/patient-details/views/patient-daily-hospital-process-report.html
@@ -1,4 +1,4 @@
-<!-- build:css styles/report.patient-daily-hospital-process.min.css -->
+<!-- build:report styles/report.patient-daily-hospital-process.min.css -->
 <link rel="stylesheet" href="../../styles/patient-daily-hospital-process-report.css" media="print"/>
 <!-- endbuild -->
 


### PR DESCRIPTION
Since reportService can load html files from any path, the css loaded by these
html always have to be relative to the path where the app is running. In our specific
case relative to '/poc/'.