### PR TITLE
Refactor form loading

### DIFF
--- a/app/poc-common/form-display/services/formLoader.js
+++ b/app/poc-common/form-display/services/formLoader.js
@@ -1,32 +1,34 @@
-'use strict';
+(function () {
+  'use strict';
 
-angular.module('poc.common.formdisplay')
-    .factory('formLoader', ['$q', 'formService', function ($q, formService) {
-        
-        var existingPromises = {};
+  angular
+    .module('poc.common.formdisplay')
+    .factory('formLoader', formLoader);
 
-        var load = function (forms) {
-            var promiseDefer = $q.defer();
-            var promises = [];
-            var loadedForms = [];
-            
-            _.forEach(forms, function(form) {
-                if (!existingPromises[form.id]) {
-                existingPromises[form.id] = formService.fetchByUuid(form.formId).then(function (response) {
-                    loadedForms[form.id] = response;
-                });
-                promises.push(existingPromises[form.id]);
-            }
-            });
-            $q.all(promises).then(function () {
-                promiseDefer.resolve(loadedForms);
-            });
+  formLoader.$inject = ['$q', 'formService'];
 
-            return promiseDefer.promise;
-        };
-        
-        return {
-            load: load
-        };
-        
-    }]);
+  /* @ngInject */
+  function formLoader($q, formService) {
+    var service = {
+      load: load
+    };
+    return service;
+
+    ////////////////
+
+    function load(forms) {
+      var formMap = {};
+
+      var loadForms = forms.map(function (form) {
+        return formService.getForm(form.formId).then(function (f) {
+          formMap[form.id] = f;
+        });
+      });
+
+      return $q.all(loadForms).then(function () {
+        return formMap;
+      });
+    }
+  }
+
+})();

--- a/app/poc-common/form-display/services/formService.js
+++ b/app/poc-common/form-display/services/formService.js
@@ -1,44 +1,52 @@
-'use strict';
-angular.module('poc.common.formdisplay')
-    .factory('formService', ['$q', '$http',function ($q, $http) {
+(function () {
+  'use strict';
 
-        var fetchByUuid = function(formUuid) {
-            var deferrable = $q.defer();
-            $http.get("/openmrs/ws/rest/v1/form" + "/" + formUuid, {
-                method: "GET",
-                params: {
-                    v: "full"
-                },
-                withCredentials: true
-            }).success(function (data) {
-                _.forEach(data.formFields, function (formField) {
-                    $http.get("/openmrs/ws/rest/v1/field" + "/" + formField.field.uuid, {
-                                method: "GET",
-                                params: {
-                                    v: "full"
-                                },
-                                withCredentials: true
-                    }).success(function (fieldConcept) {
-                        formField.fieldConcept = fieldConcept;
-                    });
-                    deferrable.resolve(data);
-                });
-            });
-            return deferrable.promise;
-        };
-        
-        var getByUuid = function(formUuid) {
-            return $http.get("/openmrs/ws/rest/v1/form" + "/" + formUuid, {
-                method: "GET",
-                params: {
-                    v: "full"
-                },
-                withCredentials: true
-            });
-        };
+  angular
+    .module('poc.common.formdisplay')
+    .factory('formService', formService);
 
-        return {
-            getByUuid: getByUuid,
-            fetchByUuid: fetchByUuid
-        };
-    }]);
+  formService.$inject = ['$q', '$http', '$log'];
+
+  /* @ngInject */
+  function formService($q, $http, $log) {
+    var service = {
+      getForm: getForm
+    };
+    return service;
+
+    ////////////////
+
+    function getForm(uuid) {
+      return $http.get("/openmrs/ws/rest/v1/form" + "/" + uuid, {
+        method: "GET",
+        params: {
+          v: "custom:(description,display,encounterType,uuid,formFields:(uuid,field:(uuid,selectMultiple,fieldType:(display),concept:(answers,set,setMembers,uuid,datatype:(display)))))"
+        },
+        withCredentials: true
+      }).then(function (response) {
+        var form = response.data;
+        form.formFields.forEach(function (f) {
+          // TODO: This field is not really necessary, should be removed after refactoring all other parts of dynamic
+          // forms to not use fieldConcept
+          f.fieldConcept = angular.copy(f.field);
+        });
+        return form;
+      });
+    }
+
+    function getFormFieldConcept(fieldUUID) {
+      return $http.get('/openmrs/ws/rest/v1/field/' + fieldUUID, {
+        params: {
+          v: "full"
+        },
+        withCredentials: true
+      }).then(function (response) {
+        return response.data;
+      }).catch(function (error) {
+        $log.error('XHR Failed for getFormFieldConcept. ' + error.data);
+        return $q.reject(error);
+      });
+    }
+  }
+
+})();


### PR DESCRIPTION
Form field concepts are now loaded in the same request as the parent form using custom representation. This should lower the number of requests fired during module initialization.

![screenshot from 2017-08-24 08-59-03](https://user-images.githubusercontent.com/1554715/29661139-66e09be2-88c3-11e7-8fa8-a80e70f9541d.png)

vs

![screenshot from 2017-08-24 09-03-06](https://user-images.githubusercontent.com/1554715/29661970-fe4c3d5e-88c5-11e7-8ee6-be53e9746f78.png)

Unfortunately this does not solve the slowness issues. :(

I think real problem is loading the form, fields, answers etc in the same request or sequentially:

    curl -u admin:eSaude123 http://localhost:8080/openmrs/ws/rest/v1/form/e28aa7aa-1d5f-11e0-b929-000c29ad1d07?v='custom:(description,display,encounterType,uuid,formFields:(uuid,field:(uuid,selectMultiple,fieldType:(display),concept:(answers,set,setMembers,uuid,datatype:(display)))))'

Is about 3MB!

It kind of worked before because those initialization scripts were not waiting for all the forms to be loaded, and it caused problems if the user tried to access one of the forms before it finished loading. I've changed that in aedba22.

[Caching](https://wiki.openmrs.org/display/docs/REST+Web+Services+API+For+Clients#RESTWebServicesAPIForClients-ETag) seems like is not working also.

We need to take a different approach with these forms, maybe some type of lazy loading.

