### PR TITLE
Workaround for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: node_js
 node_js:
   - "4.0.0"


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

The build will be slower than normal because it will use VMs instead of containers, we should revert to ```sudo:false``` after Travis sorts out the issue.