### PR TITLE
Fix #381

### DIFF
--- a/app/poc-common/clinical-services/mappers/createEncounterMapper.js
+++ b/app/poc-common/clinical-services/mappers/createEncounterMapper.js
@@ -9,6 +9,15 @@
 
   /* @ngInject */
   function createEncounterMapper() {
+
+    var CODED_DATATYPE = 'Coded';
+
+    var DATE_DATATYPE = 'Date';
+
+    var DATETIME_DATATYPE = 'Datetime';
+
+    var DATETIME_FORMAT = 'YYYY-MM-DD HH:mm';
+
     var mapper = {
       mapFromFormPayload: mapFromFormPayload
     };
@@ -118,6 +127,19 @@
     }
 
 
+    function getNonSelectMultipleObsValue(formField) {
+      var value = formField.value;
+      var dataType = formField.field.concept.datatype.display;
+      if (isAnyObject(value)) {
+        if (dataType === CODED_DATATYPE) {
+          value = ensureObject(formField.value).uuid;
+        } else if (dataType === DATE_DATATYPE || dataType === DATETIME_DATATYPE) {
+          value = moment(value).format(DATETIME_FORMAT);
+        }
+      }
+      return value;
+    }
+
     function createNonObsGroups(fields, flattenFields, person) {
       var obs = [];
       _.forEach(flattenFields, function (field) {
@@ -139,8 +161,7 @@
           } else {
             obs.push({
               concept: formField.field.concept.uuid,
-              value: (isAnyObject(formField.value) &&
-                formField.field.concept.datatype.display === 'Coded') ? ensureObject(formField.value).uuid : formField.value,
+              value: getNonSelectMultipleObsValue(formField),
               obsDatetime: Bahmni.Common.Util.DateUtil.now(),
               person: person
             });

--- a/test/spec/poc-common/clinical-services/mappers/createEncounterMapper.spec.js
+++ b/test/spec/poc-common/clinical-services/mappers/createEncounterMapper.spec.js
@@ -1,0 +1,79 @@
+'use strict';
+
+describe('createEncounterMapper', function () {
+
+  var createEncounterMapper, formPayload, formParts, patient, location, provider, jan312018;
+
+  beforeEach(module('poc.common.clinicalservices'));
+
+  beforeEach(inject(function (_createEncounterMapper_) {
+    createEncounterMapper = _createEncounterMapper_;
+    jan312018 = new Date(2018, 0, 31);
+    formPayload = {
+      encounterType: {
+        uuid: 'e278f956-1d5f-11e0-b929-000c29ad1d07'
+      },
+      form: {
+        uuid: 'e28aa7aa-1d5f-11e0-b929-000c29ad1d07',
+        fields: {
+          '0fcf9f12-2f0c-462f-81ad-b9f0bc65bfea': {
+            field: {
+              concept: {
+                datatype: {
+                  display: 'Date'
+                },
+                uuid: '088deb09-4aa4-4533-8b21-5c04f6c3e4a6'
+              }
+            },
+            value: jan312018
+          }
+        },
+        fieldType: {
+          display: 'Concept'
+        }
+      }
+    };
+    formParts = [
+      {
+        fields: [
+          {id: '0fcf9f12-2f0c-462f-81ad-b9f0bc65bfea'}
+        ]
+      }
+    ];
+    patient = 'd5b9d975-9412-4d14-a264-c72e557c9d58';
+    provider = 'e2bc25aa-1d5f-11e0-b929-000c29ad1d07';
+    location = '7fc3f286-15b1-465e-9013-b72916f58b2d';
+  }));
+
+  describe('mapFromFormPayload', function () {
+
+    it('should format date and datetime datatypes', function () {
+
+      spyOn(Bahmni.Common.Util.DateUtil, 'now').and.callFake(function () {
+        return jan312018;
+      });
+
+      var encounter = createEncounterMapper.mapFromFormPayload(formPayload, formParts, patient, location, provider, jan312018);
+
+      expect(encounter).toEqual({
+        encounterType: 'e278f956-1d5f-11e0-b929-000c29ad1d07',
+        encounterDatetime: jan312018,
+        patient: 'd5b9d975-9412-4d14-a264-c72e557c9d58',
+        location: '7fc3f286-15b1-465e-9013-b72916f58b2d',
+        form: 'e28aa7aa-1d5f-11e0-b929-000c29ad1d07',
+        provider: 'e2bc25aa-1d5f-11e0-b929-000c29ad1d07',
+        obs: [
+          {
+            concept: '088deb09-4aa4-4533-8b21-5c04f6c3e4a6',
+            value: '2018-01-31 00:00',
+            obsDatetime: jan312018,
+            person: 'd5b9d975-9412-4d14-a264-c72e557c9d58'
+          }
+        ]
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Formating obs Date and Datetime values to prevent angular $httpParamSerializer from converting them
to an ISO 8601 string before submitting.

Angular converts Date objects to ISO 8601 Strings with timezones and in OpenMRS Obs#setValueAsString
the timezone is not considered when parsing to Date or Datetime. In some cases this caused the wrong
dates to be saved in the database.