### PR TITLE
Changing the Bintray User

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_deploy:
 deploy:
   - provider: bintray
     file: "bintray.json"
-    user: "psbrandt"
+    user: "esaude-ops"
     key: $BINTRAY_API_KEY
     dry-run: false
     on:
       branch: master
   - provider: bintray
     file: "bintray-release.json"
-    user: "psbrandt"
+    user: "esaude-ops"
     key: $BINTRAY_API_KEY
     dry-run: false
     on:


### PR DESCRIPTION
For testing reasons, using `esaude-ops` instead of `psbrandt` to fix authentication errors during the build.