### PR TITLE
Workaround for dpl-1.9 failure to authenticate on bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,19 @@ before_deploy:
   - sed -i "s/__RELEASE_VERSION__/$TRAVIS_TAG/g" bintray-release.json
 deploy:
   - provider: bintray
+    edge:
+      branch: v1.8.47
     file: "bintray.json"
-    user: "esaude-ops"
+    user: "psbrandt"
     key: $BINTRAY_API_KEY
     dry-run: false
     on:
       branch: master
   - provider: bintray
+    edge:
+      branch: v1.8.47
     file: "bintray-release.json"
-    user: "esaude-ops"
+    user: "psbrandt"
     key: $BINTRAY_API_KEY
     dry-run: false
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_deploy:
 deploy:
   - provider: bintray
     file: "bintray.json"
-    user: "psbrandt"
+    user: "esaude-ops"
     key: $BINTRAY_API_KEY
     dry-run: false
     on:
       branch: master
   - provider: bintray
     file: "bintray-release.json"
-    user: "psbrandt"
+    user: "esaude-ops"
     key: $BINTRAY_API_KEY
     dry-run: false
     on:


### PR DESCRIPTION
**Dpl** is the deploy tool used for continuous deployment. As per this Github [issue](https://github.com/travis-ci/travis-ci/issues/9314), there are some problems with the latest **Dpl** version, 1.9; the workaround is to use an older version - v1.8.47. 
A permanent solution is being worked out, as seen in the above link.