### PR TITLE
Automated E2E testing using CodeceptJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *.patch
 /.vscode
 /package-lock.json
+/e2eTests/output

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /.vscode
 /package-lock.json
 /e2eTests/output
+/e2eTests/reports

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Access the server by navigating to http://localhost:9000/home in your browser.
 
 Running `grunt test` will run the unit tests with karma.
 
+## End-To-End Tests
+
+0. `npm install`
+1. `npm run wd:start` - starts Selinium
+2. `npm run e2e` - runs tests and generates a report
+3. open `/e2eTests/reports/pocE2E.html` to view a report
+
 ## Setup (Staging & Production)
 
 To deploy eSaude EMR POC to a staging or production, it is necessary deploy the distributable package to a web server such as Apache or Nginx.

--- a/codecept.json
+++ b/codecept.json
@@ -13,7 +13,9 @@
   },
   "include": {
     "I": "./e2eTests/steps_file.js",
-    "Data": "./e2eTests/data.js"
+
+    "Data": "./e2eTests/data.js",
+    "LoginPage": "./e2eTests/pages/loginPage.js"
   },
   "bootstrap": false,
   "mocha": {},

--- a/codecept.json
+++ b/codecept.json
@@ -1,0 +1,19 @@
+{
+  "tests": "./e2eTests/**/*_test.js",
+  "timeout": 10000,
+  "output": "./e2eTests/output",
+  "helpers": {
+    "Protractor": {
+      "url": "http://localhost:9000/home",
+      "driver": "hosted",
+      "browser": "chrome",
+      "rootElement": "body"
+    }
+  },
+  "include": {
+    "I": "./e2eTests/steps_file.js"
+  },
+  "bootstrap": false,
+  "mocha": {},
+  "name": "esaude-emr-poc"
+}

--- a/codecept.json
+++ b/codecept.json
@@ -20,6 +20,13 @@
     "LoginPage": "./e2eTests/pages/loginPage.js"
   },
   "bootstrap": false,
-  "mocha": {},
+  "mocha": {
+    "reporterOptions": {
+      "reportDir": "e2eTest/reports",
+      "inlineAssets": true,
+      "reportPageTitle": "E2E Test Reports",
+      "reportTitle": "E2E Test Reports"
+    }
+  },
   "name": "esaude-emr-poc"
 }

--- a/codecept.json
+++ b/codecept.json
@@ -3,15 +3,17 @@
   "timeout": 10000,
   "output": "./e2eTests/output",
   "helpers": {
-    "Protractor": {
+    "Puppeteer": {
       "url": "http://localhost:9000/home",
       "driver": "hosted",
       "browser": "chrome",
-      "rootElement": "body"
+      "rootElement": "body",
+      "show": true
     }
   },
   "include": {
-    "I": "./e2eTests/steps_file.js"
+    "I": "./e2eTests/steps_file.js",
+    "Data": "./e2eTests/data.js"
   },
   "bootstrap": false,
   "mocha": {},

--- a/codecept.json
+++ b/codecept.json
@@ -15,6 +15,8 @@
     "I": "./e2eTests/steps_file.js",
 
     "Data": "./e2eTests/data.js",
+
+    "DashboardPage": "./e2eTests/pages/dashboardPage.js",
     "LoginPage": "./e2eTests/pages/loginPage.js"
   },
   "bootstrap": false,

--- a/codecept.json
+++ b/codecept.json
@@ -22,7 +22,8 @@
   "bootstrap": false,
   "mocha": {
     "reporterOptions": {
-      "reportDir": "e2eTest/reports",
+      "reportDir": "e2eTests/reports",
+      "reportFilename": "pocE2E",
       "inlineAssets": true,
       "reportPageTitle": "E2E Test Reports",
       "reportTitle": "E2E Test Reports"

--- a/e2eTests/dashboard_test.js
+++ b/e2eTests/dashboard_test.js
@@ -1,0 +1,12 @@
+
+Feature('Dashboard');
+
+Before((I) => { // or Background
+  const loginStatus = I.login()
+	loginStatus.successful()
+});
+
+Scenario('Logout successfully', (I, DashboardPage) => {
+	const logoutStatus = DashboardPage.logout()
+	logoutStatus.successful()
+});

--- a/e2eTests/data.js
+++ b/e2eTests/data.js
@@ -1,0 +1,18 @@
+module.exports = {
+	users: {
+		admin: {
+			username: 'admin',
+			password: 'eSaude123',
+		},
+
+		invalidUsername: {
+			username: 'invalidUsername',
+			password: 'eSaude123'
+		},
+
+		invalidPassword: {
+			username: 'admin',
+			password: 'thisIsInvalid',
+		},
+	},
+}

--- a/e2eTests/data.js
+++ b/e2eTests/data.js
@@ -1,3 +1,4 @@
+// Data useful for tests
 module.exports = {
 	users: {
 		admin: {

--- a/e2eTests/login_test.js
+++ b/e2eTests/login_test.js
@@ -2,16 +2,16 @@
 Feature('Login');
 
 Scenario('Login as admin successful', (I, Data) => {
-	I.login(Data.users.admin)
-	I.waitForElement('#home-link', 5);
+	const loginStatus = I.login(Data.users.admin)
+	loginStatus.successful()
 });
 
-Scenario('Login with invalid username', (I, Data) => {
-	I.login(Data.users.invalidUsername)
-	I.waitForElement('div[ng-show="vm.errorMessageTranslateKey"]', 5)
+Scenario('Login with invalid username', (I, Data,) => {
+	const loginStatus = I.login(Data.users.invalidUsername)
+	loginStatus.unsuccessful()
 });
 
 Scenario('Login with invalid password', (I, Data) => {
-	I.login(Data.users.invalidPassword)
-	I.waitForElement('div[ng-show="vm.errorMessageTranslateKey"]', 5)
+	const loginStatus = I.login(Data.users.invalidPassword)
+	loginStatus.unsuccessful()
 });

--- a/e2eTests/login_test.js
+++ b/e2eTests/login_test.js
@@ -1,17 +1,17 @@
 
 Feature('Login');
 
-Scenario('Login as admin successful', (I, Data) => {
+Scenario('Login successful with admin credentials', (I, Data) => {
 	const loginStatus = I.login(Data.users.admin)
 	loginStatus.successful()
 });
 
-Scenario('Login with invalid username', (I, Data,) => {
+Scenario('Login failed with invalid username', (I, Data) => {
 	const loginStatus = I.login(Data.users.invalidUsername)
 	loginStatus.unsuccessful()
 });
 
-Scenario('Login with invalid password', (I, Data) => {
+Scenario('Login failed with invalid password', (I, Data) => {
 	const loginStatus = I.login(Data.users.invalidPassword)
 	loginStatus.unsuccessful()
 });

--- a/e2eTests/login_test.js
+++ b/e2eTests/login_test.js
@@ -1,0 +1,17 @@
+
+Feature('Login');
+
+Scenario('Login as admin successful', (I, Data) => {
+	I.login(Data.users.admin)
+	I.waitForElement('#home-link', 5);
+});
+
+Scenario('Login with invalid username', (I, Data) => {
+	I.login(Data.users.invalidUsername)
+	I.waitForElement('div[ng-show="vm.errorMessageTranslateKey"]', 5)
+});
+
+Scenario('Login with invalid password', (I, Data) => {
+	I.login(Data.users.invalidPassword)
+	I.waitForElement('div[ng-show="vm.errorMessageTranslateKey"]', 5)
+});

--- a/e2eTests/pages/dashboardPage.js
+++ b/e2eTests/pages/dashboardPage.js
@@ -1,0 +1,40 @@
+'use strict';
+
+let I;
+
+module.exports = {
+
+  _init() {
+    I = actor();
+  },
+
+  dropdown: {
+    hamburgerButton: {css: '.dropdown-toggle'},
+    logoutButton: {css: '#logout'},
+  },
+
+  homeLink: '#home-link',
+
+  isLoaded() {
+    I.waitForElement(this.homeLink, 5)
+    I.seeInCurrentUrl('/dashboard')
+  },
+
+  // Logs the user in
+  logout() {
+    I.wait(1)
+    I.click(this.dropdown.hamburgerButton)
+    I.click(this.dropdown.logoutButton)
+
+    // Helps the caller detect whether logout was
+    // successful or not
+    return {
+      // If logout was successful we should be taken to the home page
+      successful() {
+        const loginPage = require('./loginPage')
+        loginPage.isLoaded()
+        return loginPage
+      },
+    }
+  },
+}

--- a/e2eTests/pages/dashboardPage.js
+++ b/e2eTests/pages/dashboardPage.js
@@ -10,7 +10,7 @@ module.exports = {
 
   dropdown: {
     hamburgerButton: {css: '.dropdown-toggle'},
-    logoutButton: {css: '#logout'},
+    logoutButton: {css: 'a[log-out]'},
   },
 
   homeLink: '#home-link',

--- a/e2eTests/pages/loginPage.js
+++ b/e2eTests/pages/loginPage.js
@@ -1,0 +1,39 @@
+'use strict';
+
+let I;
+
+module.exports = {
+
+  _init() {
+    I = actor();
+  },
+
+  fields: {
+    username: '#username',
+    password: '#password'
+  },
+
+  loginButton: {css: '.btn'},
+
+  // Logs the user in
+  login(username, password) {
+    I.amOnPage('/index.html#/login')
+    I.fillField(this.fields.username, username);
+    I.fillField(this.fields.password, password);
+    I.click(this.loginButton);
+
+    // Helps the caller detect whether login was
+    // successful or not
+    return {
+      // If login was successful we should be taken to the dashboard
+      successful() {
+        I.waitForElement('#home-link', 5)
+      },
+
+      // If the login was unsuccessful an error should pop up
+      unsuccessful() {
+        I.waitForElement('div[ng-show="vm.errorMessageTranslateKey"]', 5)
+      },
+    }
+  },
+}

--- a/e2eTests/pages/loginPage.js
+++ b/e2eTests/pages/loginPage.js
@@ -15,6 +15,11 @@ module.exports = {
 
   loginButton: {css: '.btn'},
 
+  isLoaded() {
+    I.waitForElement(this.fields.username, 5)
+    I.seeInCurrentUrl('/login')
+  },
+
   // Logs the user in
   login(username, password) {
     I.amOnPage('/index.html#/login')
@@ -27,7 +32,9 @@ module.exports = {
     return {
       // If login was successful we should be taken to the dashboard
       successful() {
-        I.waitForElement('#home-link', 5)
+        const dashboardPage = require('./dashboardPage')
+        dashboardPage.isLoaded()
+        return dashboardPage
       },
 
       // If the login was unsuccessful an error should pop up

--- a/e2eTests/steps_file.js
+++ b/e2eTests/steps_file.js
@@ -1,0 +1,12 @@
+
+'use strict';
+// in this file you can append custom step methods to 'I' object
+
+module.exports = function() {
+  return actor({
+
+    // Define custom steps here, use 'this' to access default methods of I.
+    // It is recommended to place a general 'login' function here.
+
+  });
+}

--- a/e2eTests/steps_file.js
+++ b/e2eTests/steps_file.js
@@ -6,6 +6,11 @@ module.exports = function() {
 
     // Log the user in
     login: function(userInfo) {
+      // Default to the admin user
+      if(!userInfo) {
+        userInfo = require('./data.js').users.admin
+      }
+
       // Create the login page object
       const loginPage = require('./pages/loginPage')
       loginPage._init()

--- a/e2eTests/steps_file.js
+++ b/e2eTests/steps_file.js
@@ -5,8 +5,12 @@
 module.exports = function() {
   return actor({
 
-    // Define custom steps here, use 'this' to access default methods of I.
-    // It is recommended to place a general 'login' function here.
+    login: function(userInfo) {
+      this.amOnPage('/index.html#/login')
+      this.fillField('#username', userInfo.username)
+      this.fillField('#password', userInfo.password)
+      this.click('.btn')
+    },
 
   });
 }

--- a/e2eTests/steps_file.js
+++ b/e2eTests/steps_file.js
@@ -1,15 +1,18 @@
 
 'use strict';
-// in this file you can append custom step methods to 'I' object
 
 module.exports = function() {
   return actor({
 
+    // Log the user in
     login: function(userInfo) {
-      this.amOnPage('/index.html#/login')
-      this.fillField('#username', userInfo.username)
-      this.fillField('#password', userInfo.password)
-      this.click('.btn')
+      // Create the login page object
+      const loginPage = require('./pages/loginPage')
+      loginPage._init()
+
+      // Login and return an object that helps callers
+      // check login status
+      return loginPage.login(userInfo.username, userInfo.password)
     },
 
   });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "eSaude EMR point of care",
   "devDependencies": {
     "async": "^0.9.2",
+    "codeceptjs": "^1.1.7",
     "connect": "^3.4.0",
     "connect-livereload": "^0.5.3",
     "eslint-config-angular": "^0.5.0",
@@ -50,9 +51,12 @@
     "karma-json-fixtures-preprocessor": "0.0.6",
     "karma-ng-html2js-preprocessor": "^1.0.0",
     "karma-spec-reporter": "0.0.25",
+    "mochawesome": "^3.0.2",
     "morgan": "^1.6.1",
     "opn": "^1.0.2",
     "portscanner": "^1.0.0",
+    "protractor": "^5.3.1",
+    "puppeteer": "^1.3.0",
     "serve": "^1.4.0",
     "serve-index": "^1.7.2",
     "serve-static": "^1.10.0",
@@ -65,7 +69,8 @@
   "dependencies": {},
   "scripts": {
     "test": "grunt test",
-    "e2e": "codeceptjs run",
+    "e2e": "./node_modules/.bin/codeceptjs run --steps --reporter mochawesome",
+    "wd:start": "node node_modules/protractor/bin/webdriver-manager update && node node_modules/protractor/bin/webdriver-manager start --standalone",
     "create-version": "npm --no-git-tag-version version",
     "publish-version": "git tag $(node -e \"console.log(require('./package.json').version);\") && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {},
   "scripts": {
     "test": "grunt test",
+    "e2e": "codeceptjs run",
     "create-version": "npm --no-git-tag-version version",
     "publish-version": "git tag $(node -e \"console.log(require('./package.json').version);\") && git push --tags"
   },


### PR DESCRIPTION
These are the initial commits for automating end-to-end testing. This work is based on prior work by @edrisse and @ynurmahomed found [here](https://github.com/edrisse/automated-e2e-testing-poc). The next step is to write tests based Carina and Christine's specs.

## What's in this PR?
- Setup work that integrates ConceptJS into POC
- A few test (i.e. Login and Dashboard)
- Simple report generation

![e2e tests](https://user-images.githubusercontent.com/2764891/38809232-bb94c6ae-4137-11e8-8739-18e8a7536522.gif)


## What is CodeceptJS? https://codecept.io/
- CodeceptJS is a wrapper around other automation frameworks
- It exposes nice, high level APIs that make reading and writing tests relatively simple
- Because it runs on mocha we can leverage mochawesome for custom reporting
- It can run tests in chrome headless so there isn't a popup

## How are these changes structured
- codecept.json defines config
- Tests are written in e2eTests/ (we may want to change this. Maybe a test folder that has unit and e2e tests)
- e2eTests/steps_file.js extends the `I` variable. This allows us to add common/useful functionality to the core element of CodeceptJS
- e2eTests/pages contain helper code for each page (e.g. login, dashboard) that makes reading and writing tests simpler

## Open questions
1) How are we going to test without relying on the UI to insert data?
2) Is puppeteer the best framework to use? -- When I used Protractor as the underlying framework I couldn't get Codecept to click on certain buttons, which cased tests to fail. To change back to Protractor and test simply change the helper name in codecept.json from "Puppeteer" to "Protractor"