### PR TITLE
Workaround for bintray restriction access. Using a temporary deploy …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ deploy:
       tags: true
 after_deploy:
   - sh scripts/trigger-docker-image-build.sh
-  - sh scripts/deploy.sh
+  - sh scripts/manual-deploy.sh

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -o xtrace
+
+if [ -z "$TRAVIS_TAG" ];
+then
+  # Deploy to dev
+ echo "Temporary alternative Deploying to dev."
+ #For now we will rely on an alternative deploy which doesn't depend on bintray
+ sshpass -p$TRAVIS_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@dev.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-manual-deploy.sh | bash';
+else
+  # Deploy to test if tag
+  echo "Deploying to test because this is a tag."
+  sshpass -p$TRAVIS_TEST_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@test-ssh.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | POC_VERSION='"$TRAVIS_TAG"' bash';
+fi


### PR DESCRIPTION
…route 
While bintray is not accessible we will be using on .travis.yml the script manual-deploy.sh, replacing the deploy.sh script for a awhile. 
Once the Bintray restriction is lifted we will restore the use of the `deploy.sh` script. 