### PR TITLE
Visit start and end same day

### DIFF
--- a/app/visit/components/visitHeader.js
+++ b/app/visit/components/visitHeader.js
@@ -17,6 +17,7 @@
   /* @ngInject */
   function VisitController($rootScope, $filter, visitService, notifier) {
 
+    var DATETIME_FORMAT = 'DD/MM/YYYY HH:mm';
 
     var dateFilter = $filter('date');
     var translateFilter = $filter('translate');
@@ -67,10 +68,12 @@
 
     function updateLastVisitMessage() {
       if (vm.lastVisit) {
+        var formatedStartDate = moment(vm.lastVisit.startDatetime).utcOffset('+0200').format(DATETIME_FORMAT);
+        var formatedStopDate = moment(vm.lastVisit.stopDatetime).utcOffset('+0200').format(DATETIME_FORMAT);
         vm.lastVisitMessage = vm.lastVisit.visitType.name + ' ' + translateFilter('COMMON_FROM') + ' '
-          + dateFilter(vm.lastVisit.startDatetime, 'short') + ' ' + translateFilter('COMMON_TO') + ' '
-          + dateFilter(vm.lastVisit.stopDatetime, 'short')
-      }
+        + formatedStartDate + ' ' + translateFilter('COMMON_TO') + ' '
+        + formatedStopDate
+    }
     }
 
     function updateConsultationMessages() {

--- a/app/visit/visitService.js
+++ b/app/visit/visitService.js
@@ -18,6 +18,8 @@
 
     var HEIGHT_CM = "e1e2e934-1d5f-11e0-b929-000c29ad1d07";
 
+    var DATETIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
     var sortByVisitStartDateTime = _.curryRight(_.sortBy, 2)(function (visit) {
       return new Date(visit.startDatetime);
     });
@@ -60,13 +62,13 @@
             return $q.reject();
           }
 
-          var now = new Date();
+          var now = moment();
           var visit = {
             patient: patient.uuid,
             visitType: isFirstVisit ? FIRST_CONSULTATION_VISIT_TYPE_UUID : FOLLOW_UP_CONSULTATION_VISIT_TYPE_UUID,
             location: currentLocation.uuid,
-            startDatetime: now,
-            stopDatetime: moment(now).endOf('day').toDate()
+            startDatetime: now.format(DATETIME_FORMAT),
+            stopDatetime: now.endOf('day').format(DATETIME_FORMAT)
           };
 
           return create(visit);

--- a/test/spec/visit/components/visitHeader.spec.js
+++ b/test/spec/visit/components/visitHeader.spec.js
@@ -111,7 +111,7 @@ describe('VisitHeaderController', function () {
 
       $rootScope.$apply();
 
-      expect(ctrl.lastVisitMessage).toEqual('SEGUIMENTO SEGUINTE S. TARV COMMON_FROM 3/19/18 9:47 AM COMMON_TO 3/20/18 12:00 AM');
+      expect(ctrl.lastVisitMessage).toEqual('SEGUIMENTO SEGUINTE S. TARV COMMON_FROM 19/03/2018 11:47 COMMON_TO 20/03/2018 02:00');
 
     });
 

--- a/test/spec/visit/visitService.spec.js
+++ b/test/spec/visit/visitService.spec.js
@@ -11,7 +11,7 @@ describe('visitService', function () {
   beforeEach(module('visit'));
 
   beforeEach(inject(function (_visitService_, $httpBackend, _$log_, _$q_, _$rootScope_, _commonService_,
-                              _sessionService_, _encounterService_, _observationsService_) {
+    _sessionService_, _encounterService_, _observationsService_) {
     visitService = _visitService_;
     $http = $httpBackend;
     $log = _$log_;
@@ -26,8 +26,8 @@ describe('visitService', function () {
   describe('search', function () {
 
     var uuid = "9e23a1bb-0615-4066-97b6-db309c9c6447";
-    var parameters = {patient: uuid, includeInactive: false, v: "custom:(uuid)"};
-    var response = {results: [1, 2, 3]};
+    var parameters = { patient: uuid, includeInactive: false, v: "custom:(uuid)" };
+    var response = { results: [1, 2, 3] };
 
     beforeEach(function () {
       $http.expectGET("/openmrs/ws/rest/v1/visit" + '?patient=' + parameters.patient + '&includeInactive=' + parameters.includeInactive
@@ -53,7 +53,7 @@ describe('visitService', function () {
 
   describe('create', function () {
 
-    var visitDetails = {patientUuid: "uuid"};
+    var visitDetails = { patientUuid: "uuid" };
 
     beforeEach(function () {
       $http.expectPOST("/openmrs/ws/rest/v1/visit").respond({});
@@ -79,7 +79,7 @@ describe('visitService', function () {
 
     var uuid = "9e23a1bb-0615-4066-97b6-db309c9c6447";
     var datetime = '2017-08-17';
-    var response = {results: [{startDatetime: datetime, stopDatetime: datetime}]};
+    var response = { results: [{ startDatetime: datetime, stopDatetime: datetime }] };
 
     beforeEach(function () {
       $http.expectGET("/openmrs/ws/rest/v1/visit" + '?patient=' + uuid + '&v=full').respond(response);
@@ -129,8 +129,8 @@ describe('visitService', function () {
   describe('checkInPatient', function () {
 
     var uuid = "9e23a1bb-0615-4066-97b6-db309c9c6447";
-    var parameters = {patient: uuid, includeInactive: false, v: "full"};
-    var csPebane = {uuid: 'e2b37662-1d5f-11e0-b929-000c29ad1d07'};
+    var parameters = { patient: uuid, includeInactive: false, v: "full" };
+    var csPebane = { uuid: 'e2b37662-1d5f-11e0-b929-000c29ad1d07' };
 
     describe('first visit', function () {
 
@@ -140,9 +140,7 @@ describe('visitService', function () {
           return csPebane;
         });
 
-        var startDateTime = new Date();
-        var stopDatetime = moment(startDateTime).endOf('day').toDate();
-        jasmine.clock().mockDate(startDateTime);
+        jasmine.clock().mockDate(moment('18/04/2018 10:30:00', 'DD/MM/YYYY HH:mm:ss').toDate());
 
         $http.expectGET("/openmrs/ws/rest/v1/visit?patient=" + parameters.patient
           + '&v=' + parameters.v)
@@ -152,14 +150,14 @@ describe('visitService', function () {
           patient: uuid,
           visitType: FIRST_CONSULTATION_VISIT_TYPE_UUID,
           location: csPebane.uuid,
-          startDatetime: startDateTime,
-          stopDatetime: stopDatetime
+          startDatetime: '2018-04-18T10:30:00',
+          stopDatetime: '2018-04-18T23:59:59'
         };
 
         $http.expectPOST('/openmrs/ws/rest/v1/visit', visitData).respond({});
 
         var created = {};
-        visitService.checkInPatient({uuid: uuid}).then(function (visit) {
+        visitService.checkInPatient({ uuid: uuid }).then(function (visit) {
           created = visit;
         });
 
@@ -170,33 +168,33 @@ describe('visitService', function () {
 
     describe('follow-up visit', function () {
 
+      var DATETIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
       it('should create a visit with follow-up consultation type', function () {
 
         spyOn(sessionService, 'getCurrentLocation').and.callFake(function () {
           return csPebane;
         });
 
-        var startDateTime = new Date();
-        var stopDatetime = moment(startDateTime).endOf('day').toDate();
-        jasmine.clock().mockDate(startDateTime);
-
-        var visits = [{voided: false}];
+        jasmine.clock().mockDate(moment('18/04/2018 10:30:00', 'DD/MM/YYYY HH:mm:ss').toDate());
+        
+        var visits = [{ voided: false }];
         $http.expectGET("/openmrs/ws/rest/v1/visit?patient=" + parameters.patient
           + '&v=' + parameters.v)
-          .respond({results: visits});
+          .respond({ results: visits });
 
         var visitData = {
           patient: uuid,
           visitType: FOLLOW_UP_CONSULTATION_VISIT_TYPE_UUID,
           location: csPebane.uuid,
-          startDatetime: startDateTime,
-          stopDatetime: stopDatetime
+          startDatetime: '2018-04-18T10:30:00',
+          stopDatetime: '2018-04-18T23:59:59'
         };
 
         $http.expectPOST('/openmrs/ws/rest/v1/visit', visitData).respond({});
 
         var created = {};
-        visitService.checkInPatient({uuid: uuid}).then(function (visit) {
+        visitService.checkInPatient({ uuid: uuid }).then(function (visit) {
           created = visit;
         });
 
@@ -214,13 +212,13 @@ describe('visitService', function () {
           return null;
         });
 
-        var visits = [{voided: false}];
+        var visits = [{ voided: false }];
         $http.expectGET("/openmrs/ws/rest/v1/visit?patient=" + parameters.patient
           + '&v=' + parameters.v)
-          .respond({results: visits});
+          .respond({ results: visits });
 
         var created = {};
-        visitService.checkInPatient({uuid: uuid}).then(function (visit) {
+        visitService.checkInPatient({ uuid: uuid }).then(function (visit) {
           created = visit;
         });
 
@@ -239,7 +237,7 @@ describe('visitService', function () {
 
   describe('getVisitHeader', function () {
 
-    var patient = {uuid: '7401f469-60ee-4cfa-afab-c1e89e2944e4'};
+    var patient = { uuid: '7401f469-60ee-4cfa-afab-c1e89e2944e4' };
 
     beforeEach(function () {
 
@@ -297,11 +295,11 @@ describe('visitService', function () {
       it('should load patient last registered BMI', function () {
 
         var getHeight = $q(function (resolve) {
-          return resolve({value: 181});
+          return resolve({ value: 181 });
         });
 
         var getWeight = $q(function (resolve) {
-          return resolve({value: 71});
+          return resolve({ value: 71 });
         });
 
         spyOn(observationsService, 'getLastPatientObs').and.returnValues(getHeight, getWeight);


### PR DESCRIPTION
Fix #522 
To replicate the issue you must change your timezone to UTC.
The solution is based on ignoring the timezone for date processing. This is archived by playing with date formats and time offsets. We want to find a more structured solution for this in the future. This should be taken care of transparently by the application framework so that we don't have to remember to ignore timezone every time we need to work with dates, and also don't spread the necessary boilerplate code around. I have a few ideas of how to achieve this and would like to work on it as soon as we deliver version 2.