### PR TITLE
Using a dev server alias to access it

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@ if [ -z "$TRAVIS_TAG" ];
 then
   # Deploy to dev
  echo "Deploying to dev."
- sshpass -p$TRAVIS_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@dev.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | bash';
+ sshpass -p$TRAVIS_USER_PASSWORD ssh -o StrictHostKeyChecking=no travis@dev-ssh.esaude.org 'curl -sL https://raw.githubusercontent.com/esaude/esaude-poc-docker/master/scripts/dev-server-deploy.sh | bash';
 else
   # Deploy to test if tag
   echo "Deploying to test because this is a tag."


### PR DESCRIPTION
The access to @dev.esaude.org isn't working after the migration of the VMs, though it's working using the alias `dev-ssh`.