### PR TITLE
Custom Translator that uses locale files of the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "mustache": "^2.3.0"
+  },
   "scripts": {
     "test": "grunt test",
     "e2e": "./node_modules/.bin/codeceptjs run --steps --reporter mochawesome",

--- a/test/e2eTests/data.js
+++ b/test/e2eTests/data.js
@@ -1,131 +1,174 @@
 // Generates a patient identifier
 const generatePatientIdentifier = () => {
-	// Generates a random number between [0,9]
-	const g = () => Math.floor(Math.random() * Math.floor(9))
+  // Generates a random number between [0,9]
+  const g = () => Math.floor(Math.random() * Math.floor(9))
 
-	// Returns a randomly generated identifier of the format
-	// "PPDDUUSS/AA/NNNNN" where each is a number between [0, 9]
-	return `${g()}${g()}${g()}${g()}${g()}${g()}${g()}${g()}/${g()}${g()}/${g()}${g()}${g()}${g()}${g()}`
+  // Returns a randomly generated identifier of the format
+  // "PPDDUUSS/AA/NNNNN" where each is a number between [0, 9]
+  return `${g()}${g()}${g()}${g()}${g()}${g()}${g()}${g()}/${g()}${g()}/${g()}${g()}${g()}${g()}${g()}`
 }
 
 // Defines the uuids of roles
 const Roles = {
-	provider: '8d94f280-c2cc-11de-8d13-0010c6dffd0f',
+  provider: '8d94f280-c2cc-11de-8d13-0010c6dffd0f',
 }
 
 // Data useful for tests
 module.exports = {
-	// Data about each user
-	users: {
+  // Data about each user
+  users: {
 
-		// The admin user
-		admin: {
-			username: 'admin',
-			password: 'eSaude123',
-			person: {
-				names: [
-					{
-						givenName: "AdminFirstName",
-						familyName: "AdminLastName"
-					}
-				],
-				gender: 'F',
-			},
-		},
+    // The admin user
+    admin: {
+      username: 'admin',
+      password: 'eSaude123',
+      person: {
+        names: [
+          {
+            givenName: "AdminFirstName",
+            familyName: "AdminLastName"
+          }
+        ],
+        gender: 'F',
+      },
+    },
 
-		// A user with a username that is not expected to be in the database
-		invalidUsername: {
-			username: 'invalidUsername',
-			password: 'eSaude123',
-		},
+    // A user with a username that is not expected to be in the database
+    invalidUsername: {
+      username: 'invalidUsername',
+      password: 'eSaude123',
+    },
 
-		// The admin user with an invalid password
-		invalidPassword: {
-			username: 'admin',
-			password: 'thisIsInvalid',
-		},
+    // The admin user with an invalid password
+    invalidPassword: {
+      username: 'admin',
+      password: 'thisIsInvalid',
+    },
 
-		// A user that is not a provider
-		nonProvider: {
-			username: 'nonProvider',
-			password: 'testPass',
-			person: {
-				names: [
-					{
-						givenName: "NonProviderFirstName",
-						familyName: "NonProviderLastName"
-					}
-				],
-				gender: 'M',
-			},
+    // A user that is not a provider
+    nonProvider: {
+      username: 'nonProvider',
+      password: 'testPass',
+      person: {
+        names: [
+          {
+            givenName: "NonProviderFirstName",
+            familyName: "NonProviderLastName"
+          }
+        ],
+        gender: 'M',
+      },
 			/*roles: [
 				Roles.provider,
 			],*/
-		},
+    },
 
-		patient1: {
-			"identifiers": [
-				{
-					"identifier": "30532063/03/33743",
-					"identifierType": "e2b966d0-1d5f-11e0-b929-000c29ad1d07", // NID (SERVICO TARV)
-					"location": "4c34a53f-b0c2-4315-9829-1a07f76e10a8", // Zumba
-					"preferred": true
-				}
-			],
-			person: {
-				names: [
-					{
-						givenName: "Patient1FirstName",
-						familyName: "Patient1LastName"
-					}
-				],
-				gender: 'M',
-				birthdate: (new Date('2002-10-2')).toISOString(),
-			},
-		},
+    patient1: {
+      "identifiers": [
+        {
+          "identifier": "30532063/03/33743",
+          "identifierType": "e2b966d0-1d5f-11e0-b929-000c29ad1d07", // NID (SERVICO TARV)
+          "location": "4c34a53f-b0c2-4315-9829-1a07f76e10a8", // Zumba
+          "preferred": true
+        }
+      ],
+      person: {
+        names: [
+          {
+            givenName: "Patient1FirstName",
+            familyName: "Patient1LastName"
+          }
+        ],
+        gender: 'M',
+        birthdate: (new Date('2002-10-2')).toISOString(),
+      },
+    },
 
-		patient2: {
-			"identifiers": [
-				{
-					"identifier": "88654738/73/84441",
-					"identifierType": "e2b966d0-1d5f-11e0-b929-000c29ad1d07", // NID (SERVICO TARV)
-					"location": "4c34a53f-b0c2-4315-9829-1a07f76e10a8", // Zumba
-					"preferred": true
-				}
-			],
-			person: {
-				names: [
-					{
-						givenName: "Patient2FirstName",
-						familyName: "Patient2LastName"
-					}
-				],
-				gender: 'F',
-				birthdate: (new Date('1994-3-19')).toISOString(),
-			},
-		},
-	},
+    patient2: {
+      "identifiers": [
+        {
+          "identifier": "88654738/73/84441",
+          "identifierType": "e2b966d0-1d5f-11e0-b929-000c29ad1d07", // NID (SERVICO TARV)
+          "location": "4c34a53f-b0c2-4315-9829-1a07f76e10a8", // Zumba
+          "preferred": true
+        }
+      ],
+      person: {
+        names: [
+          {
+            givenName: "Patient2FirstName",
+            familyName: "Patient2LastName"
+          }
+        ],
+        gender: 'F',
+        birthdate: (new Date('1994-3-19')).toISOString(),
+      },
+    },
+  },
 
-	// Utilities for generating provider related data
-	providers: {
-		// Generates JSON that can be used to make
-		// the user a provider
-		generateJsonFromUser: function (user) {
-			return {
-				person: user.person.uuid,
-				identifier: user.systemId
-			}
-		},
-	},
+  // Utilities for generating provider related data
+  providers: {
+    // Generates JSON that can be used to make
+    // the user a provider
+    generateJsonFromUser: function (user) {
+      return {
+        person: user.person.uuid,
+        identifier: user.systemId
+      }
+    },
+  },
 
-	// Uuids for programs
-	programs: {
-		SERVICO_TARV_CUIDADO: '7b2e4a0a-d4eb-4df7-be30-78ca4b28ca99',
-		SERVICO_TARV_TRATAMENTO: 'efe2481f-9e75-4515-8d5a-86bfde2b5ad3',
-		TUBERCULOSE: '142d23c4-c29f-4799-8047-eb3af911fd21',
-		CCR: '611f0a6b-68b7-4de7-bc7a-fd021330eef8',
-		CCU: '8954a750-079e-4bf2-940c-b4f71ea8bb15',
-		PTV_ETV: '06057245-ca21-43ab-a02f-e861d7e54593',
-		CLINICA_MOVEL: 'fb455824-fb53-45ab-bf5a-a81482ff6848',
-	}
+  // Uuids for programs
+  programs: {
+    SERVICO_TARV_CUIDADO: '7b2e4a0a-d4eb-4df7-be30-78ca4b28ca99',
+    SERVICO_TARV_TRATAMENTO: 'efe2481f-9e75-4515-8d5a-86bfde2b5ad3',
+    TUBERCULOSE: '142d23c4-c29f-4799-8047-eb3af911fd21',
+    CCR: '611f0a6b-68b7-4de7-bc7a-fd021330eef8',
+    CCU: '8954a750-079e-4bf2-940c-b4f71ea8bb15',
+    PTV_ETV: '06057245-ca21-43ab-a02f-e861d7e54593',
+    CLINICA_MOVEL: 'fb455824-fb53-45ab-bf5a-a81482ff6848',
+  },
+
+  patients: {
+    patient1: {
+      "identifiers": [
+        {
+          "identifier1": "12345678/22/987654",
+          "identifier2": "452631256M",
+          "identifier3": "12345678/22/98799",
+          "alternativeIdentifier1": "12345",
+          "alternativeIdentifier2": "234567",
+          "preferred": true
+        }
+      ],
+      person: {
+        names: [
+          {
+            givenName: "Malocy",
+            familyName: "Ladon"
+          }
+        ],
+        gender: 'F',
+        birthdate: "24/06/1995",
+      },
+      contacts: {
+        country: "Mocambique",
+        province: "Gaza",
+        district: "Chibuto",
+        administrativePost: "Chibuto Sede",
+        locality: "Sede",
+        neighborhood: "Longuene",
+        cell: "A",
+        street: "567",
+        reference: "",
+        phoneNumber1: "845695235",
+        phoneNumber2: "845625123",
+        provenience: "PROVEDOR PRIVADO",
+      },
+      tests: {
+        testType: "TESTE RÁPIDO HIV",
+        testDate: (new Date('2018-01-01')).toISOString(),
+      }
+    },
+  }
 }

--- a/test/e2eTests/i18n.js
+++ b/test/e2eTests/i18n.js
@@ -1,0 +1,109 @@
+/**
+ * Module dependencies.
+ */
+
+var Mustache = require('mustache');
+var util = require('util');
+var fs = require('fs');
+var path = require('path');
+
+/**
+ * I18n class.
+ *
+ * @param {Object} options
+ * @api public
+ */
+function I18n(options) {
+  this.options = util._extend(util._extend({}, this.defaults), options);
+  this.loadTranslations();
+}
+
+/**
+ * Load translations from directory.
+ *
+ * @api private
+ */
+I18n.prototype.loadTranslations = function () {
+  var self = this;
+  var translations = {};
+  var llTranslations = {};
+  var locale;
+  var dirs = fs.readdirSync(this.options.directory);
+  var obj = {};
+  for (var i in dirs) {
+    var name = this.options.directory + dirs[i];
+
+    if (fs.statSync(name).isDirectory()) {
+      var files = fs.readdirSync(name);
+      files.forEach(function (file) {
+
+        try {
+          locale = path.basename(file).split('.').shift();
+          if (locale.includes("pt")) {
+            obj = Object.assign(obj, JSON.parse(fs.readFileSync(self.getDirectoryPath(dirs[i], locale))));
+            translations[locale] = obj;
+            llTranslations[locale.split('_')[0]] = locale;
+          }
+
+        } catch (err) {
+          console.log(err);
+        }
+      });
+    } else {
+      dirs.push(name);
+    }
+  }
+
+  this.translations = translations;
+  this.llTranslations = llTranslations;
+};
+
+/**
+ * Get all translations for locale.
+ *
+ * @param {String} locale
+ * @return {Object}
+ * @api private
+ */
+I18n.prototype.getTranslations = function (locale) {
+  return this.translations[locale] || {};
+};
+
+
+/**
+ * Translate a key.
+ *
+ * @param {String} locale
+ * @param {String} key
+ * @param {Object} view
+ * @param {Object} options
+ * @return {String}
+ * @api public
+ */
+I18n.prototype.translate = I18n.prototype.t = function (locale, key, view, options) {
+  var translations = this.getTranslations(locale);
+  var value = Mustache.render(translations[key] || key, view, translations);
+  return value;
+};
+
+
+/**
+ * Get normalized path directory.
+ *
+ * @param {String} locale
+ * @return {String}
+ */
+I18n.prototype.getDirectoryPath = function (module, locale) {
+  return path.normalize(path.join(this.options.directory, module + '/' + locale + '.json'));
+};
+
+
+/**
+ * Default options.
+ */
+I18n.prototype.defaults = {
+  defaultLocale: 'locale_pt',
+  directory: __dirname + '/../../../poc_config/openmrs/i18n/',
+};
+
+module.exports = I18n;

--- a/test/e2eTests/pages/page.js
+++ b/test/e2eTests/pages/page.js
@@ -1,4 +1,5 @@
-const Component = require('./components/component')
+const Component = require('./components/component');
+const I18n = require('./../i18n');
 
 // Represents a page on the POC website
 // A page can consist of multiple components
@@ -11,41 +12,51 @@ const Component = require('./components/component')
 // For example, when the patientSearch component is added to a page
 // tests can call page.search(...)
 class Page {
-	constructor(options) {
-		// Make sure the components array is inialized
-		options.components = options.components || [];
+  constructor(options) {
+    // Make sure the components array is inialized
+    options.components = options.components || [];
 
-		this.options = options;
+    this.options = options;
 
-		// Every page should have the header component
-		if(!this.options.components.includes('header')) {
-			this.options.components.push('header');
-		}
-	}
+    // Every page should have the header component
+    if (!this.options.components.includes('header')) {
+      this.options.components.push('header');
+    }
 
-	_init() {
-		this.I = actor();
+    // Add translator
+    this.i18n = new I18n({
+      directory: __dirname + '/../../../poc_config/openmrs/i18n/'
+    });
+  }
 
-		// Add each component to this page
-		this.options.components.forEach(name => this._addComponent(name));
-	}
+  _init() {
+    this.I = actor();
 
-	// Validates that the page is loaded
-	isLoaded() {
-		this.I.waitForElement(this.options.isLoaded.element, 5);
-		this.I.seeInCurrentUrl(this.options.isLoaded.urlPart);
+    // Add each component to this page
+    this.options.components.forEach(name => this._addComponent(name));
+  }
 
-		// If there is an overlay, wait for it
-		this.I.waitForInvisible('#overlay', 10);
-	}
+  // Validates that the page is loaded
+  isLoaded() {
+    this.I.waitForElement(this.options.isLoaded.element, 5);
+    this.I.seeInCurrentUrl(this.options.isLoaded.urlPart);
 
-	// Gets an instance of the component
-	// and copies its properties and functions
-	// to this page
-	_addComponent(componentName) {
-		const component = Component.create(componentName);
-		component.addToPage(this);
-	}
+    // If there is an overlay, wait for it
+    this.I.waitForInvisible('#overlay', 10);
+  }
+
+  // Gets an instance of the component
+  // and copies its properties and functions
+  // to this page
+  _addComponent(componentName) {
+    const component = Component.create(componentName);
+    component.addToPage(this);
+  }
+
+  // TODO: Set locale automatically
+  translate(key) {
+    return this.i18n.t('locale_pt', key);
+  }
 }
 
 module.exports = Page;

--- a/test/e2eTests/pages/registrationDashboardPage.js
+++ b/test/e2eTests/pages/registrationDashboardPage.js
@@ -1,9 +1,72 @@
 const Page = require('./page')
 
-module.exports = new Page({
-  isLoaded: {
-    element: '[ui-sref="dashboard.program"]',
-    urlPart: '/registration/#/dashboard',
-  },
-  components: ['patientSearch', 'checkIn'],
-});
+const LOG_TAG = '[RegistrationDashboardPage]';
+
+class RegistrationDashboardPage extends Page {
+
+  constructor() {
+    super({
+      isLoaded: {
+        element: '[ui-sref="dashboard.program"]',
+        urlPart: '/registration/#/dashboard',
+      },
+      components: ['patientSearch', 'checkIn'],
+    });
+
+    this.buttons = {
+      nextStep: { css: '#next-step' },
+      cancel: locate('button').find('span').withText('Cancel'),
+      addIdentifier: locate('button').find('span').withText(this.translate('REGISTRATION_ADD_IDENTIFIER')),
+      confirm: { css: '#confirm' },
+    };
+
+    this.tabs = {
+      identifiers: locate('a').withChild('span').withText('1'),
+      name: locate('a').withChild('span').withText('2'),
+      gender: locate('a').withChild('span').withText('3'),
+      age: locate('a').withChild('span').withText('4'),
+      address: locate('a').withChild('span').withText('5'),
+      contacts: locate('a').withChild('span').withText('6'),
+      testing: locate('a').withChild('span').withText('7'),
+    };
+
+    this.fields = {
+      nid: 'input[ng-model="pi.identifier"',
+      identifierType: { css: 'form select[id=patient_identifier_type]' },
+      givenName: { css: '#givenName' },
+      familyName: { css: '#patientSurname' },
+      nickname: { css: '#Alcunha' },
+      birthDate: { css: '#createdDate1' },
+      country: { css: '#country' },
+      province: { css: '#stateProvince' },
+      district: { css: '#countyDistrict' },
+      administrativePost: { css: '#address2' },
+      locality: { css: '#address6' },
+      neighborhood: { css: '#address5' },
+      cell: { css: '#address3' },
+      street: { css: '#address1' },
+      provenience: { css: 'form select[id=Proveniência]' },
+      reference: { css: '#Ponto de Referência' },
+      phone1: { css: '#Numero de Telefone 1' },
+      phone2: { css: '#Numero de Telefone 2' },
+      hivTestDate: { css: '#Data do teste HIV' },
+      testType: { css: '#Tipo de teste HIV' },
+      testResult: { css: '#Resultado do Teste HIV' }
+    };
+  }
+
+  // Verify if the new patient page is loaded
+  verifyNewPatientPage() {
+    this.I.seeInCurrentUrl('/#/patient/new/identifier')
+    this.I.seeElement(this.tabs.identifiers);
+    this.I.seeElement(this.tabs.name);
+    this.I.seeElement(this.tabs.gender);
+    this.I.seeElement(this.tabs.age);
+    this.I.seeElement(this.tabs.address);
+    this.I.seeElement(this.tabs.contacts);
+    this.I.seeElement(this.tabs.testing);
+    this.I.see('NID (SERVICO TARV)');
+  }
+}
+
+module.exports = new RegistrationDashboardPage();

--- a/test/e2eTests/pages/registrationPage.js
+++ b/test/e2eTests/pages/registrationPage.js
@@ -1,9 +1,29 @@
 const Page = require('./page')
 
-module.exports = new Page({
-  isLoaded: {
-    element: '[ng-app="registration"]',
-    urlPart: '/registration',
-  },
-  components: ['patientSearch'],
-})
+const LOG_TAG = '[RegistrationPage]';
+
+class RegistrationPage extends Page {
+
+  constructor() {
+    super({
+      isLoaded: {
+        element: '[ng-app="registration"]',
+        urlPart: '/registration',
+      },
+      components: ['patientSearch'],
+    });
+
+    this.newPatientButton = { css: '#new-patient' };
+  }
+
+  clickNewPatienButton() {
+    this.I.waitForElement(this.newPatientButton);
+    this.I.click(this.newPatientButton);
+
+    this.I.say(`${LOG_TAG} waiting for registration dashboard page to load`);
+    this.I.waitForInvisible('#overlay', 5);
+    this.I.wait(1);
+  }
+}
+
+module.exports = new RegistrationPage();

--- a/test/e2eTests/tests/registerPatient_test.js
+++ b/test/e2eTests/tests/registerPatient_test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+
+// Test for:
+// https://docs.google.com/document/d/123Dmfh0gn8gZdiZmN91PKTf8-4K06ZEdtT-Xg4_pz2c/edit#
+
+Feature('Register Patient');
+
+const LOG_TAG = '[RegisterPatientTests]';
+
+Before(async (I, Apis, Data) => {
+  I.say(`${LOG_TAG} Starting Patient Registration Tests`);
+});
+
+
+Scenario('Validate tab sequence', (I, RegistrationDashboardPage) => {
+  I.say(`${LOG_TAG} login`);
+  let dashboardPage = I.login();
+
+  I.say(`${LOG_TAG} Navigate to the registration page`);
+  const registrationPage = dashboardPage.navigateToRegistrationPage();
+
+  I.say(`${LOG_TAG} Click on the New Patient button`);
+  registrationPage.clickNewPatienButton();
+
+  I.say(`${LOG_TAG} Make sure the new patient page is loaded`);
+  RegistrationDashboardPage.verifyNewPatientPage();
+
+  const tabSequenseMessage = RegistrationDashboardPage.translate('FOLLOW_SEQUENCE_OF_TABS');
+
+  I.say(`${LOG_TAG} Validating tab sequence`);
+
+  I.click(RegistrationDashboardPage.tabs.name)
+  I.see(RegistrationDashboardPage.translate('ERROR_REQUIRED'));
+
+  I.click(RegistrationDashboardPage.tabs.gender);
+  I.see(tabSequenseMessage);
+
+  I.click(RegistrationDashboardPage.tabs.age);
+  I.see(tabSequenseMessage);
+
+  I.click(RegistrationDashboardPage.tabs.address);
+  I.see(tabSequenseMessage);
+
+  I.click(RegistrationDashboardPage.tabs.contacts);
+  I.see(tabSequenseMessage);
+
+  I.click(RegistrationDashboardPage.tabs.testing)
+  I.see(tabSequenseMessage);
+})


### PR DESCRIPTION
I tested some translation modules but they expect the locale files in one directory which is not our case. Our locale files are in different directories (lab, vitals, social, etc) and some locales are shared across the applications. I added a custom translator based on i18n-node module that reads through the sub-directories. 
The translator (i18n,js) needs some refactoring. As of now we can use it for the tests  under development.