### PR TITLE
Only extend angular eslint in app folder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,3 @@
-extends: angular
 env:
   es6: true
 rules:

--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -1,0 +1,1 @@
+extends: angular


### PR DESCRIPTION
Fixes some errors on `e2eTests` (#654).